### PR TITLE
Add projections to MongoDB queries to limit returned fields

### DIFF
--- a/server/db/donations.js
+++ b/server/db/donations.js
@@ -2,7 +2,14 @@ const dbo = require("./conn");
 
 module.exports.get = () => {
   const db = dbo.getDb();
-  return db.collection("donations").find({}).toArray();
+  return db
+    .collection("donations")
+    .find({})
+    .project({
+      name: 0,
+      email: 0,
+    })
+    .toArray();
 };
 
 module.exports.add = (data) => {

--- a/server/db/mask-requests.js
+++ b/server/db/mask-requests.js
@@ -2,7 +2,20 @@ const dbo = require("./conn");
 
 module.exports.get = () => {
   const db = dbo.getDb();
-  return db.collection("maskrequests").find({}).toArray();
+  return db
+    .collection("maskrequests")
+    .find({})
+    .project({
+      requestorType: 0,
+      organizationName: 0,
+      organizationType: 0,
+      name: 0,
+      email: 0,
+      address: 0,
+      postal: 0,
+      province: 0,
+    })
+    .toArray();
 };
 
 module.exports.add = (data) => {

--- a/test/server/db/donations.test.js
+++ b/test/server/db/donations.test.js
@@ -10,19 +10,20 @@ describe("db/donations.js", () => {
 
   test("add() adds a donation", async () => {
     const donation = {
-      name: "New Donation",
-      email: "new-donation@example.com",
+      name: "dZcb",
+      email: "dZcb@example.com",
       maskAmnt: 1,
       totalDonation: 1 * 1.25,
-      msg: "New Donation Message",
+      msg: "dZcb Donation Message",
       timestamp: new Date(),
     };
 
     await donations.add(donation);
 
     const result = await donations.get();
+    const { maskAmnt, msg, timestamp } = donation;
     expect(result).toEqual(
-      expect.arrayContaining([expect.objectContaining(donation)])
+      expect.arrayContaining([expect.objectContaining({ maskAmnt, msg, timestamp })])
     );
   });
 });

--- a/test/server/db/mask-requests.test.js
+++ b/test/server/db/mask-requests.test.js
@@ -24,15 +24,18 @@ describe("db/mask-requests.js", () => {
       province: "Ontario",
       email: "email@example.com",
       msg: "Message",
-      requestFulfilled: false,
+      requestFulfilled: true,
       timestamp: new Date(),
     };
 
     await maskRequests.add(maskRequest);
 
     const result = await maskRequests.get();
+    const { maskAmntRegular, maskAmntSmall, msg, requestFulfilled, testAmnt, timestamp } = maskRequest;
     expect(result).toEqual(
-      expect.arrayContaining([expect.objectContaining(maskRequest)])
+      expect.arrayContaining([expect.objectContaining({
+        maskAmntRegular, maskAmntSmall, msg, requestFulfilled, testAmnt, timestamp
+      })])
     );
   });
 });

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -10,11 +10,11 @@ describe("dbapi", () => {
   describe("donations", () => {
     test("POST /api/donation_add should add a donation and return 201", () => {
       const donation = {
-        name: "Name",
-        email: "email@example.com",
+        name: "nDuX",
+        email: "nDuX@example.com",
         maskAmnt: 10,
         totalDonation: 10 * 1.25,
-        msg: "Message",
+        msg: "nDuX Donation Message",
         timestamp: new Date(),
       };
 
@@ -32,11 +32,11 @@ describe("dbapi", () => {
 
     test("A donation added should exist in returned results", async () => {
       const donation = {
-        name: "New Donation",
-        email: "new-donation@example.com",
-        maskAmnt: 1,
-        totalDonation: 1 * 1.25,
-        msg: "New Donation Message",
+        name: "6EjR",
+        email: "6EjR@example.com",
+        maskAmnt: 3,
+        totalDonation: 3 * 1.25,
+        msg: "6EjR Donation Message",
         timestamp: new Date(),
       };
 
@@ -47,13 +47,10 @@ describe("dbapi", () => {
         .get("/api/get_donations")
         .expect(200)
         .then((res) => {
+          const { maskAmnt, msg, timestamp } = donation;
           expect(res.body).toEqual(
             expect.arrayContaining([
-              expect.objectContaining({
-                ...donation,
-                // The timestamp will be an ISO string vs. Date Object
-                timestamp: donation.timestamp.toISOString(),
-              }),
+              expect.objectContaining({ maskAmnt, msg, timestamp: timestamp.toISOString() }),
             ])
           );
         });
@@ -126,12 +123,16 @@ describe("dbapi", () => {
         .get("/api/get_mask_requests")
         .expect(200)
         .then((res) => {
+          const { maskAmntRegular, maskAmntSmall, testAmnt, msg, timestamp } = maskRequest;
           expect(res.body).toEqual(
             expect.arrayContaining([
               expect.objectContaining({
-                ...maskRequest,
+                maskAmntRegular,
+                maskAmntSmall,
+                testAmnt,
+                msg,
                 // The timestamp will be an ISO string vs. Date Object
-                timestamp: maskRequest.timestamp.toISOString(),
+                timestamp: timestamp.toISOString(),
               }),
             ])
           );

--- a/test/server/routes/stripeapi.test.js
+++ b/test/server/routes/stripeapi.test.js
@@ -46,8 +46,6 @@ describe("stripeapi", () => {
       expect(data).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            email: orderDetails.email,
-            name: orderDetails.name,
             maskAmnt: orderDetails.maskAmnt,
             msg: orderDetails.donationMsg,
           }),


### PR DESCRIPTION
This PR adds projections to the database collections returned by the Mongo queries, limiting the fields.

A more efficient fix is needed down the road, which does the aggregation on the server vs. sending all this data, but I wanted to start with this.