### PR TITLE
Add /api/stats and /api/messages API endpoints

### DIFF
--- a/server/db/donations.js
+++ b/server/db/donations.js
@@ -1,4 +1,17 @@
 const dbo = require("./conn");
+const { toInt } = require('../util');
+
+/**
+ * Donations Schema:
+ *
+ * _id: "61e86f3791676123aaab97d2"
+ * name: "John Smith"
+ * email: "jsmith@example.com"
+ * maskAmnt :15,
+ * totalDonation: 18.75
+ * msg: "I hope this helps"
+ * timestamp: "1642622725"
+ */
 
 module.exports.get = () => {
   const db = dbo.getDb();
@@ -15,4 +28,12 @@ module.exports.get = () => {
 module.exports.add = (data) => {
   const db = dbo.getDb();
   return db.collection("donations").insertOne(data);
+};
+
+module.exports.stats = async () => {
+  const db = dbo.getDb();
+  const donations = await db.collection("donations").find({}).project({ maskAmnt: 1 }).toArray();
+  return {
+    masksDonated: donations.reduce((total, { maskAmnt }) => total + toInt(maskAmnt), 0),
+  };
 };

--- a/server/db/mask-requests.js
+++ b/server/db/mask-requests.js
@@ -1,4 +1,22 @@
 const dbo = require("./conn");
+const { toInt } = require('../util');
+
+/**
+ * Mask Request Schema:
+ *
+ * _id: "61e86ee591676123aaab97d1"
+ * requestorType: "individual" | "organization"
+ * organizationName: "Organization Name" | null
+ * organizationType: "School, etc" | null
+ * name: "John Smith"
+ * address: "123 Main St."
+ * maskAmntRegular: 2
+ * maskAmntSmall: 1
+ * email: "jsmith@email.com"
+ * msg: "Thank you so much"
+ * timestamp: "2022-01-19T20:04:52.611Z"
+ * requestFulfilled: true | false
+ */
 
 module.exports.get = () => {
   const db = dbo.getDb();
@@ -21,4 +39,55 @@ module.exports.get = () => {
 module.exports.add = (data) => {
   const db = dbo.getDb();
   return db.collection("maskrequests").insertOne(data);
+};
+
+module.exports.stats = async () => {
+  const db = dbo.getDb();
+  const maskRequests = await db
+    .collection("maskrequests")
+    .find({})
+    .project({
+      testAmnt: 1,
+      requestFulfilled: 1,
+      maskAmnt: 1,
+      maskAmntSmall: 1,
+      maskAmntRegular: 1,
+    })
+    .toArray();
+
+  let masksRequested = 0;
+  let masksFulfilled = 0;
+  let testsRequested = 0;
+  let testsFulfilled = 0;
+
+   maskRequests.forEach(({ testAmnt, requestFulfilled, maskAmnt, maskAmntSmall, maskAmntRegular }) => {
+      testsRequested += toInt(testAmnt);
+      masksRequested += toInt(maskAmntSmall) + toInt(maskAmntRegular);
+
+      if (requestFulfilled) {
+        testsFulfilled += toInt(testAmnt);
+        masksFulfilled += toInt(maskAmntSmall) + toInt(maskAmntRegular);
+      }
+    });
+
+  return {
+    masksRequested,
+    masksFulfilled,
+    testsRequested,
+    testsFulfilled,
+  };
+};
+
+module.exports.messages = async (count = 25) => {
+  const db = dbo.getDb();
+  const messages = await db
+    .collection("maskrequests")
+    .find({})
+    .project({ msg: 1, timestamp: 1 })
+    .sort({ timestamp: -1 })
+    .limit(count)
+    .toArray();
+
+  // Remove any empty/null messages
+  return messages.filter(({ msg }) => msg?.length);
 };

--- a/server/routes/dbapi.js
+++ b/server/routes/dbapi.js
@@ -5,6 +5,34 @@ const maskRequests = require('../db/mask-requests');
 
 const router = express.Router();
 
+// Get stats for donations and mask requests.
+router.get("/api/stats", async (req, res, next) => {
+  try {
+    const [donationsStats, maskRequestsStats] = await Promise.all([
+      donations.stats(),
+      maskRequests.stats(),
+    ]);
+    res.json({
+      ...donationsStats,
+      ...maskRequestsStats,
+      unfundedMasks: maskRequestsStats.masksRequested > donationsStats.masksDonated ?
+        maskRequestsStats.masksRequested - donationsStats.masksDonated : 0,
+    });
+  } catch(err) {
+    next(err);
+  }
+});
+
+// Get messages from donations and mask requests
+router.get("/api/messages", async (req, res, next) => {
+  const count = parseInt(req.query.count, 10) || 25;
+  try {
+    res.json(await maskRequests.messages(count));
+  } catch(err) {
+    next(err);
+  }
+});
+
 // Get all donations.
 router.get("/api/get_donations", async (req, res, next) => {
   try {

--- a/server/util.js
+++ b/server/util.js
@@ -1,0 +1,1 @@
+module.exports.toInt = (value) => value|0;

--- a/test/server/db/mask-requests.test.js
+++ b/test/server/db/mask-requests.test.js
@@ -38,4 +38,33 @@ describe("db/mask-requests.js", () => {
       })])
     );
   });
+
+  test("messages() gets recent messages", async () => {
+    const maskRequest = {
+      requestorType: "individual",
+      organizationName: null,
+      organizationType: null,
+      name: "z67g",
+      address: "Address",
+      maskAmntRegular: 1,
+      maskAmntSmall: 1,
+      testAmnt: 1,
+      postal: "M5W 1E6",
+      province: "Ontario",
+      email: "z67g@example.com",
+      msg: "z67g Message",
+      requestFulfilled: false,
+      timestamp: new Date(),
+    };
+
+    await maskRequests.add(maskRequest);
+
+    const result = await maskRequests.messages();
+    const { msg, timestamp } = maskRequest;
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({
+        msg, timestamp
+      })])
+    );
+  });
 });

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -2,10 +2,251 @@ const request = require("supertest");
 
 const { connectToServer, close } = require("../../../server/db/conn");
 const app = require("../../../server/api");
+const donations = require("../../../server/db/donations");
+const maskRequests = require("../../../server/db/mask-requests");
 
 describe("dbapi", () => {
   beforeAll((done) => connectToServer(done));
   afterAll((done) => close(done));
+
+  describe("/api/messages", () => {
+    test("GET /api/messages should include the expected properties", () =>
+      request(app)
+        .get("/api/messages")
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .then((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        })
+    );
+
+    test("Specifying a ?count should limit the number of messages returned", async () => {
+      // Add a donation
+      await request(app)
+        .post("/api/donation_add")
+        .send({
+          name: "j8Y5",
+          email: "j8Y5@example.com",
+          maskAmnt: 1,
+          totalDonation: 1 * 1.25,
+          msg: "j8Y5 Donation Message",
+          timestamp: new Date(),
+        })
+        .expect(201);
+
+      // Add a mask request
+      await request(app)
+        .post("/api/mask_request_add")
+        .send({
+          requestorType: "individual",
+          organizationName: null,
+          organizationType: null,
+          name: "k3yG",
+          address: "Address",
+          maskAmntRegular: 3,
+          maskAmntSmall: 3,
+          testAmnt: 6,
+          postal: "M5W 1E6",
+          province: "Ontario",
+          email: "k3yG@example.com",
+          msg: "k3yG Message",
+          requestFulfilled: false,
+          timestamp: new Date(),
+        })
+        .expect(201);
+
+      return request(app)
+        .get("/api/messages?count=1")
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .then((res) => {
+          expect(res.body.length).toBe(1);
+        })
+    });
+
+    test("Messages should include most recent mask request", async () => {
+      const maskRequest = {
+        requestorType: "individual",
+        organizationName: null,
+        organizationType: null,
+        name: "n6yG",
+        address: "Address",
+        maskAmntRegular: 3,
+        maskAmntSmall: 3,
+        testAmnt: 6,
+        postal: "M5W 1E6",
+        province: "Ontario",
+        email: "n6yG@example.com",
+        msg: "n6yG Message",
+        requestFulfilled: false,
+        timestamp: new Date(),
+      };
+
+      // Add a Mask Request
+      await request(app)
+        .post("/api/mask_request_add")
+        .send(maskRequest)
+        .expect(201);
+    
+      return request(app)
+        .get("/api/messages")
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .then((res) => {
+          expect(res.body).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                msg: maskRequest.msg,
+                timestamp: maskRequest.timestamp.toISOString(),
+              })
+            ])
+          );
+        })
+    });
+  });
+
+  describe("/api/stats", () => {
+    const ensureTotalUnfundedMasks = (unfunded, requested, donated) => {
+      if (requested > donated) {
+        expect(unfunded).toEqual(requested - donated);
+      } else {
+        expect(unfunded).toEqual(0);
+      }
+    };
+
+    test("GET /api/stats should include the expected properties", () =>
+      request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .then((res) => {
+          expect(typeof res.body.masksDonated).toBe('number');
+          expect(typeof res.body.masksRequested).toBe('number');
+          expect(typeof res.body.masksFulfilled).toBe('number');
+          expect(typeof res.body.testsRequested).toBe('number');
+          expect(typeof res.body.testsFulfilled).toBe('number');
+          expect(typeof res.body.unfundedMasks).toBe('number');
+        })
+    );
+
+    test("Adding a donation should update stats", async () => {
+      // 1. Get the original stats
+      const { body: original } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      // 2. Add a donation
+      await request(app)
+        .post("/api/donation_add")
+        .send({
+          name: "h8b6",
+          email: "h8b6@example.com",
+          maskAmnt: 1,
+          totalDonation: 1 * 1.25,
+          msg: "h8b6 Donation Message",
+          timestamp: new Date(),
+        })
+        .expect(201);
+
+      // 3. Make sure the stats reflect the donation
+      const { body: updated } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      expect(updated.masksDonated).toEqual(original.masksDonated + 1);
+      expect(updated.masksRequested).toEqual(original.masksRequested);
+      expect(updated.masksFulfilled).toEqual(original.masksFulfilled);
+      expect(updated.testsRequested).toEqual(original.testsRequested);
+      expect(updated.testsFulfilled).toEqual(original.testsFulfilled);
+      ensureTotalUnfundedMasks(updated.unfundedMasks, updated.masksRequested, updated.masksDonated);
+    });
+
+    test("Adding an unfulfilled mask request should update stats", async () => {
+      // 1. Get the original stats
+      const { body: original } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      // 2. Add a mask request
+      await request(app)
+        .post("/api/mask_request_add")
+        .send({
+          requestorType: "individual",
+          organizationName: null,
+          organizationType: null,
+          name: "Name",
+          address: "Address",
+          maskAmntRegular: 3,
+          maskAmntSmall: 3,
+          testAmnt: 6,
+          postal: "M5W 1E6",
+          province: "Ontario",
+          email: "email@example.com",
+          msg: "Message",
+          requestFulfilled: false,
+          timestamp: new Date(),
+        })
+        .expect(201);
+
+      // 3. Make sure the stats reflect the mask request
+      const { body: updated } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      expect(updated.masksDonated).toEqual(original.masksDonated);
+      expect(updated.masksRequested).toEqual(original.masksRequested + 6);
+      expect(updated.masksFulfilled).toEqual(original.masksFulfilled);
+      expect(updated.testsRequested).toEqual(original.testsRequested + 6);
+      expect(updated.testsFulfilled).toEqual(original.testsFulfilled);
+      ensureTotalUnfundedMasks(updated.unfundedMasks, updated.masksRequested, updated.masksDonated);
+    });
+
+    test("Adding a fulfilled mask request should update stats", async () => {
+      // 1. Get the original stats
+      const { body: original } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      // 2. Add a mask request
+      await request(app)
+        .post("/api/mask_request_add")
+        .send({
+          requestorType: "individual",
+          organizationName: null,
+          organizationType: null,
+          name: "Name",
+          address: "Address",
+          maskAmntRegular: 4,
+          maskAmntSmall: 4,
+          testAmnt: 8,
+          postal: "M5W 1E6",
+          province: "Ontario",
+          email: "email@example.com",
+          msg: "Message",
+          requestFulfilled: true,
+          timestamp: new Date(),
+        })
+        .expect(201);
+
+      // 3. Make sure the stats reflect the mask request
+      const { body: updated } = await request(app)
+        .get("/api/stats")
+        .expect("Content-Type", /json/)
+        .expect(200);
+
+      expect(updated.masksDonated).toEqual(original.masksDonated);
+      expect(updated.masksRequested).toEqual(original.masksRequested + 8);
+      expect(updated.masksFulfilled).toEqual(original.masksFulfilled);
+      expect(updated.testsRequested).toEqual(original.testsRequested + 8);
+      expect(updated.testsFulfilled).toEqual(original.testsFulfilled);
+      ensureTotalUnfundedMasks(updated.unfundedMasks, updated.masksRequested, updated.masksDonated);
+    });
+  });
 
   describe("donations", () => {
     test("POST /api/donation_add should add a donation and return 201", () => {

--- a/test/server/util.test.js
+++ b/test/server/util.test.js
@@ -1,0 +1,13 @@
+const util = require("../../server/util");
+
+describe("util", () => {
+  describe("toInt()", () => {
+    test("toInt() should return 0 if value is null", () => {
+      expect(util.toInt(null)).toEqual(0);
+    });
+
+    test("toInt() should return an integer if value is a double", () => {
+      expect(util.toInt(3.14)).toEqual(3);
+    });
+  });
+});


### PR DESCRIPTION
Part 1 of #85, this adds two new API endpoints:

1. `/api/stats` calculates all the totals and values needed for the Summary page, without needing to send all the data
2. `/api/messages` gets the last `N` (defaults to `25)` messages in the `maskrequests` collection in reverse chronological order, with empty messages filtered out

Once this is running in production, I'll switch the front-end over to use them.