### PR TITLE
Fix alignment of FAQ questions and answers

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -94,14 +94,26 @@ p#message {
   margin-bottom: 7.5vh;
 }
 
-h4#question {
+.question-answer {
+  width: 100%;
+  max-width: 1450px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h4.question {
   margin: 1vh auto;
   width: 70%;
 }
 
-p#answer {
+p.answer {
   margin: 0 auto;
   width: 70%;
+}
+
+p.answer a {
+  width: 100%;
+  color: #3171d7;
 }
 
 /* 4. Privacy Page */

--- a/src/views/FAQ.js
+++ b/src/views/FAQ.js
@@ -48,29 +48,35 @@ import QA from './QA.js';
 
 const FAQItem = (props) => {
   return (
-    <Col xs={12} className="d-flex justify-content-left text-left display-linebreak">
-      <div className='pt-5'>
-        <h4 id="question">{props.question}</h4>
-        <Linkify><p id="answer"> {props.answer}</p></Linkify>
-      </div>
-    </Col>
+    <Row className="d-flex justify-content-center no-margin pt-3">
+      <Col xs={12} className="d-flex justify-content-left text-left display-linebreak">
+        <div className='pt-5 question-answer'>
+          <h4 className="question">{props.question}</h4>
+          <p className="answer"><Linkify>{props.answer}</Linkify></p>
+        </div>
+      </Col>
+    </Row>
   );
 }
 const FAQPage = () => {
   return (
     <div className="faq">
       <PageNavbar/>
-        <Hero
-          heading="Frequently asked questions"
-          body="Commonly asked questions and answers."/>
-        <Row className="d-flex justify-content-center no-margin pt-3">
-          {QA.map((question, idx) => (
-            <FAQItem
-              question={question.question}
-              answer={question.answer}/>
-          ))}
-        </Row>
-        <SimpleFooter/>
+      <Hero
+        heading="Frequently asked questions"
+        body="Commonly asked questions and answers."
+      />
+      <Container fluid="xl">
+      {
+        QA.map(({question, answer}) => (
+          <FAQItem
+            key={question}
+            question={question}
+            answer={answer}/>
+        ))
+      }
+      </Container>
+      <SimpleFooter/>
     </div>
   );
 }


### PR DESCRIPTION
The alignment of items in the FAQ jumps around.  It happens due to shorter sentences not using enough width to fill the space, so it wraps.  This fixes things so that they always take 100% of the available width.  I've also fixed a bug with how CSS is being applied, to use classes vs. repeating `id` (you can't have the same `id` used more than once), and I've improved the colour contrast on links for accessibility.

Here are some before/after screenshots:

<img width="1335" alt="Screen Shot 2022-05-05 at 9 03 54 PM" src="https://user-images.githubusercontent.com/427398/167057720-3f8bf076-b39a-423b-9937-643531052b34.png">
<img width="1419" alt="Screen Shot 2022-05-05 at 10 35 38 PM" src="https://user-images.githubusercontent.com/427398/167057721-1fe58956-9e04-4fdf-b1e6-f6d4085ec246.png">
