### PR TITLE
Remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "dotenv": "^10.0.0",
       "express": "^4.17.2",
       "headroom.js": "0.12.0",
-      "moment": "latest",
       "mongodb": "^4.2.2",
       "node-sass": "latest",
       "nouislider": "14.7.0",
@@ -69,17 +68,12 @@
       "swr": "^1.3.0"
    },
    "devDependencies": {
-      "@types/googlemaps": "3.43.3",
-      "@types/markerclustererplus": "2.1.33",
       "@types/react": "17.0.4",
-      "eslint-plugin-flowtype": "5.7.2",
       "gulp": "4.0.2",
       "gulp-append-prepend": "1.0.9",
       "jest": "^28.0.3",
-      "jquery": "3.6.0",
       "mongodb-memory-server": "^8.5.2",
-      "supertest": "^6.2.3",
-      "typescript": "4.2.4"
+      "supertest": "^6.2.3"
    },
    "overrides": {
       "glob-parent": "latest",

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "nodemon app.js",
     "start": "node app.js"
   },
   "author": "",
@@ -13,7 +14,9 @@
     "cors": "^2.8.5",
     "express": "^4.17.2",
     "mongodb": "^4.2.2",
-    "nodemon": "^2.0.15",
     "stripe": "^8.195.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.15"
   }
 }


### PR DESCRIPTION
Based on discussion in #93, this removes unused deps so they don't need to get updated.

While doing this, I notice that `package-lock.json` is in `.gitignore`.  In a follow-up, this should get removed, and the lock file used to help deal with version pinning.  Right now, the version that actually gets installed will be different per installation.