### PR TITLE
Add /donate success Thank You page

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
       "react-router": "5.2.0",
       "react-router-dom": "5.2.0",
       "react-scripts": "latest",
+      "react-share": "^4.4.0",
       "reactstrap": "8.9.0",
       "swr": "^1.3.0"
    },

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -168,6 +168,22 @@ p.answer a {
 	color: #0000FF;
 }
 
+.thank-you {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.social-share-icons {
+  margin-top: 32px;
+  display: flex;
+  justify-content: center;
+}
+
+.social-share-icon {
+  margin-left: 8px;
+}
+
 @media only screen and (max-width: 768px) {
   /* For mobile phones: */
 

--- a/src/components/DonateThankYou.js
+++ b/src/components/DonateThankYou.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { Container, Row, Col } from "reactstrap";
+import {
+  FacebookShareButton,
+  FacebookIcon,
+  LinkedinShareButton,
+  LinkedinIcon,
+  RedditShareButton,
+  RedditIcon,
+  TwitterShareButton,
+  TwitterIcon,
+  WhatsappShareButton,
+  WhatsappIcon,
+} from "react-share";
+
+const shareUrl = "https://donatemask.ca/";
+const title =
+  "I'm supporting the Donate A Mask charity to help provide high-quality masks for vulnerable people, you should too!";
+
+const DonateThankYou = () => {
+  return (
+    <Container className="thank-you">
+      <Row>
+        <Col>
+          <h3 className="display-3">Donation Successful. Thank You!</h3>
+
+          <p>We appreciate your generous donation.</p>
+          <p>
+            Consider helping us spread more awareness about our charity's work
+            through your social media:
+          </p>
+
+          <section className="social-share-icons">
+            <div className="social-share-icon">
+              <FacebookShareButton url={shareUrl} quote={title}>
+                <FacebookIcon size={32} round />
+              </FacebookShareButton>
+            </div>
+            <div className="social-share-icon">
+              <TwitterShareButton url={shareUrl} title={title}>
+                <TwitterIcon size={32} round />
+              </TwitterShareButton>
+            </div>
+            <div className="social-share-icon">
+              <RedditShareButton
+                url={shareUrl}
+                title={title}
+                windowWidth={660}
+                windowHeight={460}
+              >
+                <RedditIcon size={32} round />
+              </RedditShareButton>
+            </div>
+            <div className="social-share-icon">
+              <WhatsappShareButton url={shareUrl} title={title} separator=":: ">
+                <WhatsappIcon size={32} round />
+              </WhatsappShareButton>
+            </div>
+            <div className="social-share-icon">
+              <LinkedinShareButton url={shareUrl}>
+                <LinkedinIcon size={32} round />
+              </LinkedinShareButton>
+            </div>
+          </section>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default DonateThankYou;

--- a/src/views/Donate.js
+++ b/src/views/Donate.js
@@ -1,62 +1,33 @@
-/*!
+import React from "react";
+import { useLocation } from "react-router-dom";
+import { Row } from "reactstrap";
 
-=========================================================
-* Argon Design System React - v1.1.0
-=========================================================
-
-* Product Page: https://www.creative-tim.com/product/argon-design-system-react
-* Copyright 2020 Creative Tim (https://www.creative-tim.com)
-* Licensed under MIT (https://github.com/creativetimofficial/argon-design-system-react/blob/master/LICENSE.md)
-
-* Coded by Creative Tim
-
-=========================================================
-
-* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-*/
-import React, {useState} from "react";
-// nodejs library that concatenates classes
-import classnames from "classnames";
-
-// reactstrap components
-import {
-  Badge,
-  Button,
-  Card,
-  CardBody,
-  CardImg,
-  FormGroup,
-  Input,
-  InputGroupAddon,
-  InputGroupText,
-  InputGroup,
-  Container,
-  Row,
-  Col
-} from "reactstrap";
-
-// core components
-import PageNavbar from "components/Navbars/PageNavbar.js";
-import DonateForm from "components/DonateForm.js"
-import RequestForm from "components/RequestForm.js"
-import Hero from 'components/Hero.js'
-import SimpleFooter from 'components/SimpleFooter.js';
-
+import PageNavbar from "components/Navbars/PageNavbar";
+import DonateForm from "components/DonateForm";
+import DonateThankYou from "components/DonateThankYou";
+import Hero from "components/Hero";
+import SimpleFooter from "components/SimpleFooter";
 
 const DonatePage = () => {
+  // If we're returning from a successful Stripe donation,
+  // the URL will include ?success=true
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const donationSuccess = params.get("success") === "true";
+
   return (
     <>
-    <PageNavbar/>
+      <PageNavbar />
       <Hero
         heading="Donate a mask"
-        body="Support the Donate A Mask Charity Project with a single or recurring donation. 100% of your donation goes towards helping vulnerable people."/>
+        body="Support the Donate A Mask Charity Project with a single or recurring donation. 100% of your donation goes towards helping vulnerable people."
+      />
       <Row className="d-flex justify-content-center no-margin pt-5">
-        <DonateForm/>
+        {donationSuccess ? <DonateThankYou /> : <DonateForm />}
       </Row>
-      <SimpleFooter/>
+      <SimpleFooter />
     </>
   );
-}
+};
 
 export default DonatePage;


### PR DESCRIPTION
Fixes #101.  This gets the ball rolling on having something to indicate that the Stripe donations worked (i.e. ,all of the wording, layout, etc, can be improved in follow-ups).  I've leveraged @Sync271's great suggestion re: using the `?success=true` param, and used that to determine whether to show the donation form or a thank-you screen.  Here's what it looks like:

<img width="1208" alt="Screen Shot 2022-05-15 at 9 39 41 PM" src="https://user-images.githubusercontent.com/427398/168505988-b299b554-5f6f-43fe-97e9-31222798f631.png">

At the bottom, I also include social share buttons, which look like this if you click one (here's Twitter):

<img width="1212" alt="Screen Shot 2022-05-15 at 9 40 03 PM" src="https://user-images.githubusercontent.com/427398/168505981-afa1f23c-04b7-4495-a242-6d9e03e18153.png">

**NOTE: you need to run `npm install` before you can build this**