### PR TITLE
Add explicit cache-control for /api/* routes to avoid stale content

### DIFF
--- a/server/routes/dbapi.js
+++ b/server/routes/dbapi.js
@@ -12,7 +12,13 @@ router.get("/api/stats", async (req, res, next) => {
       donations.stats(),
       maskRequests.stats(),
     ]);
-    res.json({
+
+    // Explicitly add cache-control to prevent Passenger/Apache using a long
+    // default. For /api/* we want short-lived cache (10 min), but will tolerate stale
+    // content while it's being updated (600=10 min, 60=1 min, 86400=1 day)
+    res
+      .header('Cache-Control', 'max-age=600, stale-while-revalidate=60, stale-if-error=86400')
+      .json({
       ...donationsStats,
       ...maskRequestsStats,
       unfundedMasks: maskRequestsStats.masksRequested > donationsStats.masksDonated ?
@@ -27,7 +33,12 @@ router.get("/api/stats", async (req, res, next) => {
 router.get("/api/messages", async (req, res, next) => {
   const count = parseInt(req.query.count, 10) || 25;
   try {
-    res.json(await maskRequests.messages(count));
+    // Explicitly add cache-control to prevent Passenger/Apache using a long
+    // default. For /api/* we want short-lived cache (10 min), but will tolerate stale
+    // content while it's being updated (600=10 min, 60=1 min, 86400=1 day)
+    res
+      .header('Cache-Control', 'max-age=600, stale-while-revalidate=60, stale-if-error=86400')
+      .json(await maskRequests.messages(count));
   } catch(err) {
     next(err);
   }

--- a/test/server/routes/dbapi.test.js
+++ b/test/server/routes/dbapi.test.js
@@ -10,6 +10,13 @@ describe("dbapi", () => {
   afterAll((done) => close(done));
 
   describe("/api/messages", () => {
+    test("GET /api/messages should send correct cache-control header", () =>
+      request(app)
+      .get("/api/messages")
+      .expect("Cache-Control", "max-age=600, stale-while-revalidate=60, stale-if-error=86400")
+      .expect(200)
+    );
+
     test("GET /api/messages should include the expected properties", () =>
       request(app)
         .get("/api/messages")
@@ -106,6 +113,13 @@ describe("dbapi", () => {
   });
 
   describe("/api/stats", () => {
+    test("GET /api/stats should send correct cache-control header", () =>
+      request(app)
+      .get("/api/stats")
+      .expect("Cache-Control", "max-age=600, stale-while-revalidate=60, stale-if-error=86400")
+      .expect(200)
+    );
+
     const ensureTotalUnfundedMasks = (unfunded, requested, donated) => {
       if (requested > donated) {
         expect(unfunded).toEqual(requested - donated);


### PR DESCRIPTION
@emmaelaine alerted me to a bug in my stats code, where the browser aggressively caches the old values despite new numbers being available in the database.

This is caused by Passenger/Apache adding a default `cache-control: max-age=172800`, which will cache the stats/messages for 2 days.

This fix adds explicit cache instructions for these routes, so that we'll update more frequently.